### PR TITLE
.gitignore added for egg-info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+__pycache__/
 /terminus.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/terminus.egg-info/


### PR DESCRIPTION
Since `terminus.egg-info` gets auto-generated by pip install during the conda environment creation, ignore it. Alternatively, one could add the directory. Thoughts?